### PR TITLE
Move reset to fuzzer trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "feroxfuzz"
-version = "1.0.0-rc.6"
+version = "1.0.0-rc.7"
 edition = "2021"
 authors = ["Ben 'epi' Risher (@epi052)"]
 license = "Apache-2.0"

--- a/src/client/utils.rs
+++ b/src/client/utils.rs
@@ -17,7 +17,7 @@ pub(super) fn parse_version(data: &Data) -> Result<Version, FeroxFuzzError> {
             error!(%data, "failed to parse http version; must be a valid http version when using a reqwest client");
 
             Err(FeroxFuzzError::InvalidVersionError {
-                version: format!("{}", data),
+                version: format!("{data}"),
             })
         }
     }

--- a/src/corpora/mod.rs
+++ b/src/corpora/mod.rs
@@ -1,5 +1,4 @@
 //! Corpora modeled around how the test cases are generated, i.e. from a file/folder etc...
-#![allow(clippy::use_self)] // clippy false-positive on CorpusItemType, doesn't want to apply directly to the enums that derive Serialize
 mod directory;
 mod http_methods;
 mod range;
@@ -67,6 +66,22 @@ pub enum CorpusItemType {
     ///
     /// [`Data`]: crate::input::Data
     Data(Data),
+
+    /// When the corpus item type is [`CorpusItemType::LotsOfData`], all [`Data`]
+    /// values associated with the key will be added to the corpus.
+    ///
+    /// # Note
+    ///
+    /// There are a lot of [`From`] implementations for [`Data`]. When creating
+    /// a [`CorpusItemType::Data`] item, you can probably just use `.into`:
+    ///
+    /// ```
+    /// # use feroxfuzz::corpora::CorpusItemType;
+    /// CorpusItemType::LotsOfData(["something"].into());
+    /// ```
+    ///
+    /// [`Data`]: crate::input::Data
+    LotsOfData(Vec<Data>),
 }
 
 /// Collection of all current test cases
@@ -87,7 +102,7 @@ pub trait Corpus: Named {
 /// most of the methods/traits implemented by the underlying [`Corpus`] types
 /// are implemented here as well. Meaning, you should be able to use the
 /// underlying [`Corpus`] types seamlessly through this wrapper.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[non_exhaustive]
 pub enum CorpusType {
@@ -257,10 +272,14 @@ mod typestate {
     pub trait CorpusBuildState {}
     pub struct NoItems;
     pub struct NoName;
+    pub struct NotUnique;
     pub struct HasItems;
     pub struct HasName;
+    pub struct Unique;
     impl CorpusBuildState for NoItems {}
     impl CorpusBuildState for NoName {}
+    impl CorpusBuildState for NotUnique {}
     impl CorpusBuildState for HasItems {}
     impl CorpusBuildState for HasName {}
+    impl CorpusBuildState for Unique {}
 }

--- a/src/corpora/mod.rs
+++ b/src/corpora/mod.rs
@@ -1,4 +1,5 @@
 //! Corpora modeled around how the test cases are generated, i.e. from a file/folder etc...
+#![allow(clippy::use_self)] // clippy false-positive on Action, doesn't want to apply directly to the enums that derive Serialize
 mod directory;
 mod http_methods;
 mod range;
@@ -77,7 +78,7 @@ pub enum CorpusItemType {
     ///
     /// ```
     /// # use feroxfuzz::corpora::CorpusItemType;
-    /// CorpusItemType::LotsOfData(["something"].into());
+    /// CorpusItemType::LotsOfData(vec!["something".into()]);
     /// ```
     ///
     /// [`Data`]: crate::input::Data

--- a/src/corpora/mod.rs
+++ b/src/corpora/mod.rs
@@ -1,5 +1,5 @@
 //! Corpora modeled around how the test cases are generated, i.e. from a file/folder etc...
-#![allow(clippy::use_self)] // clippy false-positive on Action, doesn't want to apply directly to the enums that derive Serialize
+#![allow(clippy::use_self)] // clippy false-positive on CorpusItemType, doesn't want to apply directly to the enums that derive Serialize
 mod directory;
 mod http_methods;
 mod range;

--- a/src/error.rs
+++ b/src/error.rs
@@ -231,6 +231,10 @@ pub enum FeroxFuzzError {
         /// underlying source error-type
         source: AcquireError,
     },
+
+    /// Represents a scheduled item that was already scheduled once before
+    #[error("Skipped a previously scheduled item")]
+    SkipScheduledItem,
 }
 
 /// Used to differentiate between different types of errors that occur when making requests.

--- a/src/fuzzers/async_fuzzer.rs
+++ b/src/fuzzers/async_fuzzer.rs
@@ -151,6 +151,16 @@ where
     pub fn scheduler_mut(&mut self) -> &mut S {
         &mut self.scheduler
     }
+
+    /// set a function to run before each fuzzing loop
+    pub fn set_pre_loop_hook(&mut self, hook: fn(&mut SharedState)) {
+        self.pre_loop_hook = Some(FuzzingLoopHook::new(hook));
+    }
+
+    /// set a function to run after each fuzzing loop
+    pub fn set_post_loop_hook(&mut self, hook: fn(&mut SharedState)) {
+        self.post_loop_hook = Some(FuzzingLoopHook::new(hook));
+    }
 }
 
 #[async_trait]

--- a/src/fuzzers/blocking_fuzzer.rs
+++ b/src/fuzzers/blocking_fuzzer.rs
@@ -100,7 +100,7 @@ where
             threads: 1,
             pre_send_logic,
             post_send_logic,
-            corpora_length: state.corpora().iter().map(|(_, v)| v.len()).sum(),
+            corpora_length: state.total_corpora_len(),
         });
 
         while self.scheduler.next().is_ok() {

--- a/src/fuzzers/blocking_fuzzer.rs
+++ b/src/fuzzers/blocking_fuzzer.rs
@@ -69,6 +69,11 @@ where
     fn post_send_logic_mut(&mut self) -> &mut LogicOperation {
         &mut self.post_send_logic
     }
+
+    fn reset(&mut self) {
+        // in case we're fuzzing more than once, reset the scheduler
+        self.scheduler.reset();
+    }
 }
 
 impl<B, D, M, O, P, S> BlockingFuzzing for BlockingFuzzer<B, D, M, O, P, S>
@@ -149,6 +154,11 @@ where
                             // todo need to add to corpus and then update the scheduler
                             state.add_data_to_corpus(&name, data)?;
                         }
+                        CorpusItemType::LotsOfData(data) => {
+                            for item in data {
+                                state.add_data_to_corpus(&name, item)?;
+                            }
+                        }
                     }
 
                     self.scheduler.update_length();
@@ -225,6 +235,11 @@ where
                             // todo need to add to corpus and then update the scheduler
                             state.add_data_to_corpus(&name, data)?;
                         }
+                        CorpusItemType::LotsOfData(data) => {
+                            for item in data {
+                                state.add_data_to_corpus(&name, item)?;
+                            }
+                        }
                     }
 
                     self.scheduler.update_length();
@@ -277,9 +292,6 @@ where
 
             self.request_id += 1;
         }
-
-        // in case we're fuzzing more than once, reset the scheduler
-        self.scheduler.reset();
 
         if let Some(hook) = &mut self.post_loop_hook {
             // call the post-loop hook if it is defined

--- a/src/fuzzers/blocking_fuzzer.rs
+++ b/src/fuzzers/blocking_fuzzer.rs
@@ -354,6 +354,21 @@ where
     pub fn request_mut(&mut self) -> &mut Request {
         &mut self.request
     }
+
+    /// get a mutable reference to the scheduler
+    pub fn scheduler_mut(&mut self) -> &mut S {
+        &mut self.scheduler
+    }
+
+    /// set a function to run before each fuzzing loop
+    pub fn set_pre_loop_hook(&mut self, hook: fn(&mut SharedState)) {
+        self.pre_loop_hook = Some(FuzzingLoopHook::new(hook));
+    }
+
+    /// set a function to run after each fuzzing loop
+    pub fn set_post_loop_hook(&mut self, hook: fn(&mut SharedState)) {
+        self.post_loop_hook = Some(FuzzingLoopHook::new(hook));
+    }
 }
 
 #[cfg(test)]

--- a/src/fuzzers/mod.rs
+++ b/src/fuzzers/mod.rs
@@ -59,6 +59,13 @@ pub trait Fuzzer {
     ///
     /// [`Decider`]: crate::deciders::Decider
     fn post_send_logic_mut(&mut self) -> &mut LogicOperation;
+
+    /// reset the internal state of the `Scheduler`, typically called by the [`Fuzzer`]
+    /// once a full iteration of the [`Corpus`] is complete
+    ///
+    /// [`Corpus`]: crate::corpora::Corpus
+    /// [`Fuzzer`]: crate::fuzzers::Fuzzer
+    fn reset(&mut self);
 }
 
 /// trait representing a fuzzer that operates asynchronously, meaning that it executes
@@ -81,6 +88,7 @@ pub trait AsyncFuzzing: Fuzzer {
             if self.fuzz_once(state).await? == Some(Action::StopFuzzing) {
                 break Ok(());
             }
+            self.reset();
         }
     }
 
@@ -116,6 +124,7 @@ pub trait AsyncFuzzing: Fuzzer {
             if self.fuzz_once(state).await? == Some(Action::StopFuzzing) {
                 return Ok(());
             }
+            self.reset();
         }
 
         Ok(())
@@ -141,6 +150,7 @@ pub trait BlockingFuzzing: Fuzzer {
             if self.fuzz_once(state)? == Some(Action::StopFuzzing) {
                 break Ok(());
             }
+            self.reset();
         }
     }
 
@@ -173,6 +183,7 @@ pub trait BlockingFuzzing: Fuzzer {
             if self.fuzz_once(state)? == Some(Action::StopFuzzing) {
                 return Ok(());
             }
+            self.reset();
         }
 
         Ok(())

--- a/src/input.rs
+++ b/src/input.rs
@@ -355,6 +355,6 @@ impl HasBytesVec for Data {
 
 impl Input for Data {
     fn generate_name(&self, idx: usize) -> String {
-        format!("{}_{}", self.format(), idx)
+        format!("{}_{idx}", self.format())
     }
 }

--- a/src/mutators/mod.rs
+++ b/src/mutators/mod.rs
@@ -165,7 +165,7 @@ pub trait Mutator: DynClone + AsAny + Named + Send + Sync {
                         &state.events(),
                         request.id,
                         "header",
-                        Data::Fuzzable(format!("{}: {}", key, value).into()),
+                        Data::Fuzzable(format!("{key}: {value}").into()),
                     );
                 }
 
@@ -175,7 +175,7 @@ pub trait Mutator: DynClone + AsAny + Named + Send + Sync {
                         &state.events(),
                         request.id,
                         "header",
-                        Data::Fuzzable(format!("{}: {}", key, value).into()),
+                        Data::Fuzzable(format!("{key}: {value}").into()),
                     );
                 }
             }
@@ -189,7 +189,7 @@ pub trait Mutator: DynClone + AsAny + Named + Send + Sync {
                         &state.events(),
                         request.id,
                         "parameter",
-                        Data::Fuzzable(format!("{}={}", key, value).into()),
+                        Data::Fuzzable(format!("{key}={value}").into()),
                     );
                 }
 
@@ -199,7 +199,7 @@ pub trait Mutator: DynClone + AsAny + Named + Send + Sync {
                         &state.events(),
                         request.id,
                         "parameter",
-                        Data::Fuzzable(format!("{}={}", key, value).into()),
+                        Data::Fuzzable(format!("{key}={value}").into()),
                     );
                 }
             }

--- a/src/processors/request.rs
+++ b/src/processors/request.rs
@@ -18,6 +18,8 @@ use tracing::instrument;
 /// from calling the analogous hook on [`Deciders`]. Those two objects may
 /// be used to produce side-effects, such as printing, logging, etc...
 ///
+/// [`Deciders`]: crate::deciders::Deciders
+///
 /// # Examples
 ///
 /// see any of the following examples for how to use `RequestProcessor`:

--- a/src/requests/request.rs
+++ b/src/requests/request.rs
@@ -420,7 +420,7 @@ impl Request {
                         error!(?directive, "Invalid directive used");
 
                         return Err(FeroxFuzzError::InvalidDirective {
-                            directive: format!("{:?}", directive),
+                            directive: format!("{directive:?}"),
                         });
                     }
                 }
@@ -686,7 +686,7 @@ impl Request {
 
             return Err(FeroxFuzzError::KeyValueParseError {
                 key_value_pair: to_split.to_vec(),
-                reason: format!("Could not find {:x?} in {:x?}", delim, to_split),
+                reason: format!("Could not find {delim:x?} in {to_split:x?}"),
             });
         }
 
@@ -746,7 +746,7 @@ impl Request {
                     error!(?dir, "Invalid directive");
 
                     return Err(FeroxFuzzError::InvalidDirective {
-                        directive: format!("{:?}", dir),
+                        directive: format!("{dir:?}"),
                     });
                 }
             },

--- a/src/schedulers/mod.rs
+++ b/src/schedulers/mod.rs
@@ -6,7 +6,7 @@ use crate::state::SharedState;
 use crate::std_ext::ops::Len;
 use crate::Named;
 
-use std::sync::atomic::Ordering;
+use std::{fmt::Display, sync::atomic::Ordering};
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -14,10 +14,12 @@ use serde::{Deserialize, Serialize};
 mod ordered;
 mod product;
 mod random;
+mod unique;
 
 pub use ordered::OrderedScheduler;
 pub use product::ProductScheduler;
 pub use random::RandomScheduler;
+pub use unique::UniqueProductScheduler;
 
 /// manages how the fuzzer gets entries from the corpus
 pub trait Scheduler: Named {
@@ -136,5 +138,15 @@ impl CorpusIndex {
 impl Len for CorpusIndex {
     fn len(&self) -> usize {
         self.length
+    }
+}
+
+impl Display for CorpusIndex {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}[{}]: {} / {}",
+            self.name, self.current, self.length, self.iterations
+        )
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -561,7 +561,7 @@ impl SharedState {
                             request,
                             corpus_name.to_string(),
                             "header",
-                            Data::Fuzzable(format!("{}: {}", key, value).into()),
+                            Data::Fuzzable(format!("{key}: {value}").into()),
                         );
                     }
                     if value.is_fuzzable() {
@@ -571,7 +571,7 @@ impl SharedState {
                             request,
                             corpus_name.to_string(),
                             "header",
-                            Data::Fuzzable(format!("{}: {}", key, value).into()),
+                            Data::Fuzzable(format!("{key}: {value}").into()),
                         );
                     }
                 }
@@ -586,7 +586,7 @@ impl SharedState {
                             request,
                             corpus_name.to_string(),
                             "parameter",
-                            Data::Fuzzable(format!("{}={}", key, value).into()),
+                            Data::Fuzzable(format!("{key}={value}").into()),
                         );
                     }
                     if value.is_fuzzable() {
@@ -596,7 +596,7 @@ impl SharedState {
                             request,
                             corpus_name.to_string(),
                             "parameter",
-                            Data::Fuzzable(format!("{}={}", key, value).into()),
+                            Data::Fuzzable(format!("{key}={value}").into()),
                         );
                     }
                 }
@@ -672,18 +672,18 @@ impl Display for SharedState {
 
         for (key, corpus) in self.corpora.iter() {
             if let Ok(guard) = corpus.read() {
-                writeln!(f, "  Corpus[{key}]={},", guard)?;
+                writeln!(f, "  Corpus[{key}]={guard},")?;
             }
         }
 
         if let Ok(guard) = self.stats().read() {
-            writeln!(f, "  Statistics={}", guard)?;
+            writeln!(f, "  Statistics={guard}")?;
         }
 
         if let Ok(guard) = self.metadata().read() {
             #[allow(clippy::significant_drop_in_scrutinee)] // doesn't appear to be an accurate lint
             for (key, value) in guard.iter() {
-                writeln!(f, "  Metadata[{key}]={:?}", value)?;
+                writeln!(f, "  Metadata[{key}]={value:?}")?;
             }
         }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -249,6 +249,35 @@ impl SharedState {
         self.corpora.clone()
     }
 
+    /// get the total length of all corpora
+    ///
+    /// i.e. the total number of elements in all corpora added together
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use feroxfuzz::error::FeroxFuzzError;
+    /// # use feroxfuzz::corpora::{Corpus, Wordlist, RangeCorpus};
+    /// # use feroxfuzz::state::SharedState;
+    /// # use std::str::FromStr;
+    /// # use feroxfuzz::prelude::Data;
+    /// # use crate::feroxfuzz::Len;
+    /// # fn main() -> Result<(), FeroxFuzzError> {
+    /// let ids = RangeCorpus::with_stop(5).name("ids").build()?;
+    /// let names = Wordlist::with_words(["bob", "alice"]).name("names").build();
+    ///
+    /// let mut state = SharedState::with_corpora([ids, names]);
+    ///
+    /// assert_eq!(state.total_corpora_len(), 7);
+    ///
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[must_use]
+    pub fn total_corpora_len(&self) -> usize {
+        self.corpora().iter().map(|(_, v)| v.len()).sum()
+    }
+
     /// get the statistics container
     #[must_use]
     pub fn stats(&self) -> Arc<RwLock<Statistics>> {


### PR DESCRIPTION
- added `UniqueProductScheduler` (most robust for runtime corpus modifications/least efficient)
- added `.unique` to wordlist builder
- added `.reset` to fuzzer trait
- added `.set_(pre|post)_loop_hook` methods to fuzzers
- added `.scheduler_mut` method to fuzzers
- fuzzers support being told to skip an item from the scheduler (used in UniqueProductScheduler)
- added ability for `AddToCorpus` Action to add single|multiple Data items  (used to only grab fuzzable fields from a Request)
- added `.total_corpora_len` method to `SharedState`