### PR TITLE
Use v2 of `cargo-semver-checks-action`

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -39,7 +39,7 @@ jobs:
           command: nextest
           args: run --all-targets --all-features
       - name: Cargo semver checks
-        uses: obi1kenobi/cargo-semver-checks-action@v1
+        uses: obi1kenobi/cargo-semver-checks-action@v2
 
   fmt:
     name: Rust fmt


### PR DESCRIPTION
Hi! As one of the contributors of cargo-semver-checks I'd want to say we're pleased to see you're using our tool!

Since we've recently released a new, completely rebuilt version of the GitHub action, I suggest using it instead of the outdated V1. It not only fixes the problems with choosing the baseline version, but also includes several improvements of the running time, which result in huge speedup of `Cargo semver checks` step: ~1m 20s in the first run compared to previous 6 minutes (and will be even less in second and each subsequent run thanks to caching the baseline rustdoc).